### PR TITLE
Merge pull request #7 from microbiomedata/related-items

### DIFF
--- a/src/components/EcosystemChart.vue
+++ b/src/components/EcosystemChart.vue
@@ -11,7 +11,7 @@
 <script>
 import { GChart } from 'vue-google-charts';
 
-import encoding from './encoding';
+import { ecosystems } from './encoding';
 
 export default {
   name: 'EcosystemChart',
@@ -26,7 +26,7 @@ export default {
   },
   data() {
     return {
-      ecosystems: encoding.ecosystems,
+      ecosystems,
       chartEvents: {
         select: () => {
           const chart = this.$refs.chart.chartObject;

--- a/src/components/FacetedSearch.vue
+++ b/src/components/FacetedSearch.vue
@@ -98,9 +98,13 @@ export default {
       deep: true,
     },
     conditions() {
-      // Check for no-op to avoid loop
+      // First check for equivalence no-op to avoid update loop
       let same = true;
       this.conditions.forEach((condition) => {
+        if (this.selected[condition.field] === undefined) {
+          // A field that faceted search cannot track (e.g. array field)
+          return;
+        }
         if (condition.op === '==' && !this.selected[condition.field].includes(condition.value)) {
           same = false;
         }
@@ -118,9 +122,13 @@ export default {
         Object.keys(this.selected).forEach((field) => { sel[field] = []; });
         this.conditions.forEach((condition) => {
           if (condition.op === '==') {
+            if (sel[condition.field] === undefined) {
+              // A field that faceted search cannot track (e.g. array field)
+              return;
+            }
             sel[condition.field].push(condition.value);
           }
-          // Otherwise don't know what to do with condition
+          // Don't know what to do with non-equality condition
         });
         this.selected = sel;
       }

--- a/src/components/LocationMap.vue
+++ b/src/components/LocationMap.vue
@@ -15,7 +15,7 @@
 import colors from 'vuetify/lib/util/colors';
 import { GChart } from 'vue-google-charts';
 
-import encoding from './encoding';
+import { ecosystems } from './encoding';
 
 export default {
   name: 'LocationMap',
@@ -30,7 +30,7 @@ export default {
   },
   data() {
     return {
-      ecosystems: encoding.ecosystems,
+      ecosystems,
       chartEvents: {
         select: () => {
           const chart = this.$refs.chart.chartObject;
@@ -67,6 +67,7 @@ export default {
     geoChartMarkerOptions() {
       return {
         displayMode: 'markers',
+        height: 400,
         colorAxis: {
           minValue: 0,
           maxValue: 3,

--- a/src/components/encoding.js
+++ b/src/components/encoding.js
@@ -1,206 +1,259 @@
 import colors from '../colors';
 
-export default {
-  type: {
-    study: {
-      icon: 'mdi-book',
-    },
-    sample: {
-      icon: 'mdi-test-tube',
-    },
-    project: {
-      icon: 'mdi-dna',
-    },
-    file: {
-      icon: 'mdi-file',
-    },
+export const types = {
+  study: {
+    icon: 'mdi-book',
+    plural: 'studies',
   },
-  ecosystems: [
-    {
-      name: 'Host-associated',
-      color: colors.hostAssociated,
-    },
-    {
-      name: 'Aquatic',
-      color: colors.aquatic,
-    },
-    {
-      name: 'Terrestrial',
-      color: colors.terrestrial,
-    },
-    {
-      name: 'Engineered',
-      color: colors.engineered,
-    },
-  ],
+  project: {
+    icon: 'mdi-dna',
+    plural: 'projects',
+  },
+  sample: {
+    icon: 'mdi-test-tube',
+    plural: 'samples',
+  },
+  file: {
+    icon: 'mdi-file',
+    plural: 'files',
+  },
+};
+
+export const fields = {
+  location: {
+    icon: 'mdi-earth',
+  },
+  latitude: {
+    icon: 'mdi-earth',
+  },
+  longitude: {
+    icon: 'mdi-earth',
+  },
+  sample_collection_site: {
+    icon: 'mdi-earth',
+  },
+  geographic_location: {
+    icon: 'mdi-earth',
+  },
+  add_date: {
+    icon: 'mdi-calendar',
+  },
+  mod_date: {
+    icon: 'mdi-calendar',
+  },
+  ecosystem: {
+    icon: 'mdi-pine-tree',
+  },
   ecosystem_category: {
-    Bioreactor: {
-      icon: 'test-tube-empty',
-      color: 'green',
-    },
-    Bioremediation: {
-      icon: 'waves',
-      color: 'black',
-    },
-    Biotransformation: {
-      icon: 'molecule',
-      color: 'pink',
-    },
-    'Built environment': {
-      icon: 'domain',
-      color: 'green',
-    },
-    'Food production': {
-      icon: 'food-apple',
-      color: 'red',
-    },
-    'Industrial production': {
-      icon: 'factory',
-      color: 'grey',
-    },
-    'Lab enrichment': {
-      icon: 'test-tube-empty',
-      color: 'grey',
-    },
-    'Lab synthesis': {
-      icon: 'flask-round-bottom',
-      color: 'blue',
-    },
-    'Laboratory developed': {
-      icon: 'flask-outline',
-      color: 'blue',
-    },
-    Modeled: {
-      icon: 'code-braces-box',
-      color: 'blue-grey',
-    },
-    Paper: {
-      icon: 'file-outline',
-      color: 'black',
-    },
-    'Solid waste': {
-      icon: 'trash-can',
-      color: 'grey',
-    },
-    Unclassified: {
-      icon: 'help-rhombus-outline',
-      color: 'grey',
-    },
-    WWTP: {
-      icon: 'air-filter',
-      color: 'cyan',
-    },
-    Wastewater: {
-      icon: 'waves',
-      color: 'brown',
-    },
-    Air: {
-      icon: 'weather-windy',
-      color: 'light-blue',
-    },
-    Aquatic: {
-      icon: 'waves',
-      color: 'blue',
-    },
-    Terrestrial: {
-      icon: 'shovel',
-      color: 'brown',
-    },
-    Algae: {
-      icon: 'waves',
-      color: 'green',
-    },
-    Amphibia: {
-      icon: 'bug',
-      color: 'green',
-    },
-    Animal: {
-      icon: 'dog',
-      color: 'brown',
-    },
-    Annelida: {
-      icon: 'bug',
-      color: 'grey',
-    },
-    Arthropoda: {
-      icon: 'spider',
-      color: 'black',
-    },
-    Birds: {
-      icon: 'twitter',
-      color: 'yellow',
-    },
-    Cnidaria: {
-      icon: 'jellyfish',
-      color: 'pink',
-    },
-    Echinodermata: {
-      icon: 'star',
-      color: 'deep-orange',
-    },
-    Endosymbionts: {
-      icon: 'bee',
-      color: 'amber',
-    },
-    Fish: {
-      icon: 'fish',
-      color: 'cyan',
-    },
-    Fungi: {
-      icon: 'mushroom',
-      color: 'deep-orange',
-    },
-    Horse: {
-      icon: 'horseshoe',
-      color: 'brown',
-    },
-    Human: {
-      icon: 'human',
-      color: 'grey',
-    },
-    Insecta: {
-      icon: 'bee',
-      color: 'black',
-    },
-    Invertebrates: {
-      icon: 'bug',
-      color: 'grey',
-    },
-    Mammals: {
-      icon: 'dog-side',
-      color: 'brown',
-    },
-    Microbial: {
-      icon: 'bug-outline',
-      color: 'green',
-    },
-    Mollusca: {
-      icon: 'octagram',
-      color: 'purple',
-    },
-    Plants: {
-      icon: 'sprout',
-      color: 'green',
-    },
-    Porifera: {
-      icon: 'waves',
-      color: 'deep-orange',
-    },
-    Protists: {
-      icon: 'bug-outline',
-      color: 'lime',
-    },
-    Protozoa: {
-      icon: 'bug-outline',
-      color: 'teal',
-    },
-    Reptilia: {
-      icon: 'turtle',
-      color: 'green',
-    },
-    Tunicates: {
-      icon: 'water',
-      color: 'indigo',
-    },
+    icon: 'mdi-pine-tree',
+  },
+  ecosystem_type: {
+    icon: 'mdi-pine-tree',
+  },
+  ecosystem_subtype: {
+    icon: 'mdi-pine-tree',
+  },
+  specific_ecosystem: {
+    icon: 'mdi-pine-tree',
+  },
+  ecosystem_path_id: {
+    icon: 'mdi-pine-tree',
+  },
+  habitat: {
+    icon: 'mdi-pine-tree',
+  },
+  community: {
+    icon: 'mdi-google-circles-communities',
+  },
+};
+
+export const ecosystems = [
+  {
+    name: 'Host-associated',
+    color: colors.hostAssociated,
+  },
+  {
+    name: 'Aquatic',
+    color: colors.aquatic,
+  },
+  {
+    name: 'Terrestrial',
+    color: colors.terrestrial,
+  },
+  {
+    name: 'Engineered',
+    color: colors.engineered,
+  },
+];
+
+// eslint-disable-next-line camelcase
+export const ecosystem_category = {
+  Bioreactor: {
+    icon: 'test-tube-empty',
+    color: 'green',
+  },
+  Bioremediation: {
+    icon: 'waves',
+    color: 'black',
+  },
+  Biotransformation: {
+    icon: 'molecule',
+    color: 'pink',
+  },
+  'Built environment': {
+    icon: 'domain',
+    color: 'green',
+  },
+  'Food production': {
+    icon: 'food-apple',
+    color: 'red',
+  },
+  'Industrial production': {
+    icon: 'factory',
+    color: 'grey',
+  },
+  'Lab enrichment': {
+    icon: 'test-tube-empty',
+    color: 'grey',
+  },
+  'Lab synthesis': {
+    icon: 'flask-round-bottom',
+    color: 'blue',
+  },
+  'Laboratory developed': {
+    icon: 'flask-outline',
+    color: 'blue',
+  },
+  Modeled: {
+    icon: 'code-braces-box',
+    color: 'blue-grey',
+  },
+  Paper: {
+    icon: 'file-outline',
+    color: 'black',
+  },
+  'Solid waste': {
+    icon: 'trash-can',
+    color: 'grey',
+  },
+  Unclassified: {
+    icon: 'help-rhombus-outline',
+    color: 'grey',
+  },
+  WWTP: {
+    icon: 'air-filter',
+    color: 'cyan',
+  },
+  Wastewater: {
+    icon: 'waves',
+    color: 'brown',
+  },
+  Air: {
+    icon: 'weather-windy',
+    color: 'light-blue',
+  },
+  Aquatic: {
+    icon: 'waves',
+    color: 'blue',
+  },
+  Terrestrial: {
+    icon: 'shovel',
+    color: 'brown',
+  },
+  Algae: {
+    icon: 'waves',
+    color: 'green',
+  },
+  Amphibia: {
+    icon: 'bug',
+    color: 'green',
+  },
+  Animal: {
+    icon: 'dog',
+    color: 'brown',
+  },
+  Annelida: {
+    icon: 'bug',
+    color: 'grey',
+  },
+  Arthropoda: {
+    icon: 'spider',
+    color: 'black',
+  },
+  Birds: {
+    icon: 'twitter',
+    color: 'yellow',
+  },
+  Cnidaria: {
+    icon: 'jellyfish',
+    color: 'pink',
+  },
+  Echinodermata: {
+    icon: 'star',
+    color: 'deep-orange',
+  },
+  Endosymbionts: {
+    icon: 'bee',
+    color: 'amber',
+  },
+  Fish: {
+    icon: 'fish',
+    color: 'cyan',
+  },
+  Fungi: {
+    icon: 'mushroom',
+    color: 'deep-orange',
+  },
+  Horse: {
+    icon: 'horseshoe',
+    color: 'brown',
+  },
+  Human: {
+    icon: 'human',
+    color: 'grey',
+  },
+  Insecta: {
+    icon: 'bee',
+    color: 'black',
+  },
+  Invertebrates: {
+    icon: 'bug',
+    color: 'grey',
+  },
+  Mammals: {
+    icon: 'dog-side',
+    color: 'brown',
+  },
+  Microbial: {
+    icon: 'bug-outline',
+    color: 'green',
+  },
+  Mollusca: {
+    icon: 'octagram',
+    color: 'purple',
+  },
+  Plants: {
+    icon: 'sprout',
+    color: 'green',
+  },
+  Porifera: {
+    icon: 'waves',
+    color: 'deep-orange',
+  },
+  Protists: {
+    icon: 'bug-outline',
+    color: 'lime',
+  },
+  Protozoa: {
+    icon: 'bug-outline',
+    color: 'teal',
+  },
+  Reptilia: {
+    icon: 'turtle',
+    color: 'green',
+  },
+  Tunicates: {
+    icon: 'water',
+    color: 'indigo',
   },
 };

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,24 @@
 import moment from 'moment';
 
+export function valueCardinality(value) {
+  if (Array.isArray(value)) {
+    return value.length;
+  }
+  return 1;
+}
+
+export function typeWithCardinality(type, cardinality) {
+  if (cardinality === 1) {
+    return type;
+  }
+  return {
+    study: 'studies',
+    project: 'projects',
+    sample: 'samples',
+    file: 'files',
+  }[type];
+}
+
 export function toSentenceCase(word) {
   if (['id', 'ncbi'].includes(word)) {
     return word.toUpperCase();


### PR DESCRIPTION
This adds a consistent way to navigate between related objects in the system, suggested by @jbeezley. In the details page for a single item, there are buttons on the bottom that initiate a search in the related type. This for example will let you query all samples associated with a study:

![image](https://user-images.githubusercontent.com/81305/73469657-b74fde00-4354-11ea-967f-02c4b31bf2ba.png)

Another addition is that clicking on a field in an item detail page will perform a search for other items whose value for that attribute matches the current item:

![image](https://user-images.githubusercontent.com/81305/73469849-ff6f0080-4354-11ea-984f-521f708de362.png)
