### PR TITLE
Adjust landing page stats layout with more stats

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -292,34 +292,54 @@ export default {
       'specific_ecosystem',
     ],
     stats: [
-      {
-        value: api.count('study'),
-        label: 'Studies',
-      },
-      {
-        value: api.facetSummary({ type: 'sample', field: 'latitude' }).length,
-        label: 'Locations',
-      },
-      {
-        value: api.facetSummary({ type: 'sample', field: 'ecosystem_path_id' }).length,
-        label: 'Habitats',
-      },
-      {
-        value: api.query('project', [{ field: 'sequencing_strategy', op: '==', value: 'Metagenome' }]).length,
-        label: 'Metagenomes',
-      },
-      {
-        value: api.query('project', [{ field: 'sequencing_strategy', op: '==', value: 'Metatranscriptome' }]).length,
-        label: 'Metatranscriptomes',
-      },
-      {
-        value: filesize(
-          api.query('data_object', []).reduce(
-            (prev, cur) => prev + (cur.file_size || 0), 0,
-          ),
-        ),
-        label: 'Data',
-      },
+      [
+        {
+          value: api.count('study'),
+          label: 'Studies',
+        },
+        {
+          value: api.facetSummary({ type: 'sample', field: 'latitude' }).length,
+          label: 'Locations',
+        },
+        {
+          value: api.facetSummary({ type: 'sample', field: 'ecosystem_path_id' }).length,
+          label: 'Habitats',
+        },
+        {
+          value: filesize(
+            api.query('data_object', []).reduce(
+              (prev, cur) => prev + (cur.file_size || 0), 0,
+            ),
+          ).replace(/\s+/g, ''),
+          label: 'Data',
+        },
+      ],
+      [
+        {
+          value: api.query('project', [{ field: 'sequencing_strategy', op: '==', value: 'Metagenome' }]).length,
+          label: 'Metagenomes',
+        },
+        {
+          value: api.query('project', [{ field: 'sequencing_strategy', op: '==', value: 'Metatranscriptome' }]).length,
+          label: 'Metatranscriptomes',
+        },
+        {
+          value: api.query('project', [{ field: 'sequencing_strategy', op: '==', value: 'Proteomics' }]).length,
+          label: 'Proteomics',
+        },
+        {
+          value: api.query('project', [{ field: 'sequencing_strategy', op: '==', value: 'Metabolomics' }]).length,
+          label: 'Metabolomics',
+        },
+        {
+          value: api.query('project', [{ field: 'sequencing_strategy', op: '==', value: 'Lipidomics' }]).length,
+          label: 'Lipidomics',
+        },
+        {
+          value: api.query('project', [{ field: 'sequencing_strategy', op: '==', value: 'Organic Matter Characterization' }]).length,
+          label: 'Organic Matter Characterization',
+        },
+      ],
     ],
   }),
   computed: {

--- a/src/components/Welcome.vue
+++ b/src/components/Welcome.vue
@@ -48,26 +48,48 @@
       @selected="addSelected($event)"
     />
     <v-container fluid>
-      <v-row>
-        <template
-          v-for="(stat, index) in stats"
+      <template
+        v-for="(statsLine, statsLineIndex) in stats"
+      >
+        <v-row
+          :key="statsLineIndex"
         >
-          <v-divider
-            v-if="index !== 0"
-            :key="`${stat.label}-divider`"
-            class="mx-4"
-            vertical
-          />
-          <v-col :key="stat.label">
-            <div class="headline text-center">
-              {{ stat.value }}
-            </div>
-            <div class="title text-center">
-              {{ stat.label }}
-            </div>
-          </v-col>
-        </template>
-      </v-row>
+          <template
+            v-for="(stat) in statsLine"
+          >
+            <v-col :key="stat.label">
+              <v-card
+                height="150"
+                outlined
+              >
+                <v-container
+                  fluid
+                  style="height: 100%"
+                >
+                  <v-row
+                    align="center"
+                    align-content="center"
+                    style="height: 100%"
+                  >
+                    <v-col
+                      cols="12"
+                      class="display-1 text-center py-1"
+                    >
+                      {{ stat.value }}
+                    </v-col>
+                    <v-col
+                      cols="12"
+                      class="title text-center py-1"
+                    >
+                      {{ stat.label }}
+                    </v-col>
+                  </v-row>
+                </v-container>
+              </v-card>
+            </v-col>
+          </template>
+        </v-row>
+      </template>
     </v-container>
   </v-card>
 </template>


### PR DESCRIPTION
Making the landing page stats 2 rows to fit more stats.

![image](https://user-images.githubusercontent.com/81305/74763485-e7044e80-524d-11ea-9eaa-724468de9e90.png)
